### PR TITLE
SSTables use binary search

### DIFF
--- a/src/sstable/constants.rs
+++ b/src/sstable/constants.rs
@@ -1,3 +1,5 @@
 pub static WORD: usize = 8;
+pub static KEY_WORD: usize = WORD;
+pub static VALUE_WORD: usize = WORD;
 pub static TOMBSTONE: &[u8] = &[];
-pub static RKV: &str = ".rkv";
+pub static RKV: &str = "rkv";

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -113,9 +113,8 @@ impl SSTable {
      * that would change the seek position to EOF,
      * Hence we explicitly change the position.
      */
-    pub fn scan(&mut self, key: &[u8]) -> io::Result<Option<Vec<u8>>> {
+    pub fn scan(&self, key: &[u8]) -> io::Result<Option<Vec<u8>>> {
         let mut file = self.open()?;
-        file.seek(SeekFrom::Start(0))?;
         let mut buf = Vec::new();
         file.read_to_end(&mut buf)?;
         let mut i: usize = 0;

--- a/src/sstable/sstable_test.rs
+++ b/src/sstable/sstable_test.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod test {
     use crate::sstable::sst::SSTable;
-    use std::panic::{self, AssertUnwindSafe};
+    use std::{panic::{self, AssertUnwindSafe}, collections::HashMap};
     use tempfile::TempDir;
 
     #[test]
@@ -18,11 +18,13 @@ mod test {
             };
             let key = b"test_key";
             let value = b"test_value";
-            match sstable.write(key, value) {
+            let mut store = HashMap::new();
+            store.insert(key.to_vec(), value.to_vec());
+            match sstable.write(&store) {
                 Ok(_) => (),
                 Err(_) => panic!("Failed write to sstable."),
             };
-            let value_read = match sstable.scan(key) {
+            let value_read = match sstable.search(key) {
                 Ok(Some(v)) => v,
                 Err(e) => panic!("{}", e),
                 _ => panic!("Failed to read value."),

--- a/src/sstable/sstable_test.rs
+++ b/src/sstable/sstable_test.rs
@@ -1,7 +1,10 @@
 #[cfg(test)]
 mod test {
     use crate::sstable::sst::SSTable;
-    use std::{panic::{self, AssertUnwindSafe}, collections::HashMap};
+    use std::{
+        collections::HashMap,
+        panic::{self, AssertUnwindSafe},
+    };
     use tempfile::TempDir;
 
     #[test]

--- a/src/store/lsm_store.rs
+++ b/src/store/lsm_store.rs
@@ -203,7 +203,7 @@ fn parallel_search(sstables: &mut Vec<SSTable>, k: Vec<u8>) -> Option<Vec<u8>> {
                     }
                 }
 
-                let value = match sstable.scan(&key) {
+                let value = match sstable.search(&key) {
                     Ok(v) => v,
                     _ => None,
                 };

--- a/src/store/lsm_store.rs
+++ b/src/store/lsm_store.rs
@@ -136,7 +136,9 @@ impl KVStore {
                 )
             );
 
-            self.flush_memtable();
+            if let Err(e) = self.flush_memtable() {
+                panic!("Failed to flush memtable because {}", e);
+            }
         }
         self.memtable.insert(k.to_vec(), v.to_vec());
     }

--- a/src/store/lsm_store.rs
+++ b/src/store/lsm_store.rs
@@ -158,6 +158,7 @@ impl KVStore {
             return Some(v.to_vec());
         }
         let n_threads = std::cmp::min(self.sstables.len(), 100);
+        parallel_search(&mut self.sstables, k.to_vec(), n_threads)
     }
 
     fn get_from_sstable(&mut self, k: &[u8]) -> Option<Vec<u8>> {
@@ -187,6 +188,67 @@ impl KVStore {
     pub fn size(&self) -> u64 {
         self.mem_size
     }
+}
+
+/// Parallel search SSTables.
+/// 
+/// sstables=Vec<SSTables> is ordered such that the most recent table is at the end.
+/// 1. We partition sstables so that multiple threads can search them in parallel.
+/// 2. We use a channel to collect results from each thread.
+fn parallel_search(sstables: &mut Vec<SSTable>, k: Vec<u8>, n_threads: usize) -> Option<Vec<u8>> {
+    let n_sstables = sstables.len();
+    let chunk_size = (n_sstables + n_threads - 1) / n_threads;
+    let sstables = Arc::new(sstables.clone());
+    let key = Arc::new(k);
+    let result: Arc<Mutex<Option<Vec<u8>>>> = Arc::new(Mutex::new(None));
+    let mut handles = vec![];
+    let last_index: Arc<Mutex<Option<usize>>> = Arc::new(Mutex::new(None));    
+
+    for i in 0..n_threads {
+        let sstables = sstables.clone();
+        let key = key.clone();
+        let result = result.clone();
+        let last_index = last_index.clone();
+
+        let start = i * chunk_size;
+        let end = std::cmp::min(start + chunk_size, n_sstables);
+
+        let handle = thread::spawn(move || {
+            let sstable_chunk = &sstables[start..end];
+            for (j, sstable) in sstable_chunk.iter().enumerate() {
+
+                let mut current_last_index = last_index.lock().unwrap();
+                if let Some(last_index) = *current_last_index {
+                    if last_index >= start + j {
+                        return;
+                    }
+                }
+
+                let value = match sstable.scan(&key) {
+                    Ok(v) => v,
+                    _ => None,
+                };
+
+                if let Some(v) = value {
+                    if v == TOMBSTONE {
+                        return;
+                    }
+                    let mut result = result.lock().unwrap();
+                    *result = Some(v);
+                    *current_last_index = Some(start + j);
+                    return;
+                }
+            }
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().expect("Failed to join thread!");
+    }
+
+    let result = result.lock().unwrap();
+    result.clone()
 }
 
 fn create_sstable(n_sstables: usize, sstable_dir: &Path) -> SSTable {

--- a/src/store/lsm_store.rs
+++ b/src/store/lsm_store.rs
@@ -157,7 +157,7 @@ impl KVStore {
             }
             return Some(v.to_vec());
         }
-        self.get_from_sstable(k)
+        let n_threads = std::cmp::min(self.sstables.len(), 100);
     }
 
     fn get_from_sstable(&mut self, k: &[u8]) -> Option<Vec<u8>> {

--- a/src/store/store_test.rs
+++ b/src/store/store_test.rs
@@ -100,6 +100,7 @@ mod test {
             (b"key2", b"value2"),
             (b"key3", b"value3"),
             (b"key4", b"value4"),
+            (b"key1", b"value7"),
             (b"key5", b"value5"),
             (b"key6", b"value6"),
             (b"key7", b"value7"),
@@ -118,15 +119,15 @@ mod test {
             store.compaction();
 
             match store.get(b"key1") {
-                Some(v) => assert_eq!(v, b"value1", "Expected value to be b'value1'"),
+                Some(v) => assert_eq!(v, b"value7", "Expected value to be b'value7'"),
                 None => panic!("Expected a value to be found'"),
             }
             match store.get(b"key2") {
-                Some(v) => assert_eq!(v, b"value2", "Expected value to be b'value1'"),
+                Some(v) => assert_eq!(v, b"value2", "Expected value to be b'value2'"),
                 None => panic!("Expected a value to be found'"),
             }
             match store.get(b"key3") {
-                Some(v) => assert_eq!(v, b"value3", "Expected value to be b'value1'"),
+                Some(v) => assert_eq!(v, b"value3", "Expected value to be b'value3'"),
                 None => panic!("Expected a value to be found'"),
             }
 


### PR DESCRIPTION
We deprecate the previous `scan` method that had the following flaws:

1. Loads the sstable to memory. This is a problem as sstables may grow as large as 100G. 
2. Searches linearly even though sstable entries are sorted on keys.

Binary search was also harder to implement partly because of the sstable anatomy and partly because we needed to implement it on disk. We solve it by creating an index file. The index file points to the starting location of all the keys. Even though the index is a relatively lighter file, we still don't load all of it into memory.

Solves #4 