### PR TITLE
Create/file utils

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 mod sstable;
 pub mod store;
+mod utils;

--- a/src/sstable/constants.rs
+++ b/src/sstable/constants.rs
@@ -1,5 +1,5 @@
 pub static WORD: usize = 8;
-pub static KEY_WORD: usize = 2;
-pub static VALUE_WORD: usize = WORD;
+pub static KEY_WORD: usize = 16 / WORD;
+pub static VALUE_WORD: usize = 32 / WORD;
 pub static TOMBSTONE: &[u8] = &[];
 pub static RKV: &str = "rkv";

--- a/src/sstable/constants.rs
+++ b/src/sstable/constants.rs
@@ -1,5 +1,5 @@
 pub static WORD: usize = 8;
-pub static KEY_WORD: usize = WORD;
+pub static KEY_WORD: usize = 2;
 pub static VALUE_WORD: usize = WORD;
 pub static TOMBSTONE: &[u8] = &[];
 pub static RKV: &str = "rkv";

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -156,3 +156,13 @@ impl SSTable {
         Ok(None)
     }
 }
+
+pub fn create_sstable(n_sstables: usize, sstable_dir: &Path) -> SSTable {
+    let uuid = Uuid::new_v4();
+    let idx = n_sstables + 1;
+    let slug = format!("{}-{}.{}", idx, uuid, RKV);
+    let dirname = sstable_dir.join(RKV).join("data");
+    create_dir_all(dirname.clone()).unwrap();
+    let filename = dirname.join(slug);
+    SSTable::new(filename, true, true, true).unwrap()
+}

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -98,11 +98,11 @@ impl SSTable {
         buf.write_all(value)
     }
 
-    fn get_key(&self, buf: &[u8], i: usize) -> usize {
+    fn get_key_size(&self, buf: &[u8], i: usize) -> usize {
         u16::from_le_bytes(buf[i..i + KEY_WORD].try_into().unwrap()) as usize
     }
 
-    fn get_value(&self, buf: &[u8], i: usize) -> usize {
+    fn get_value_size(&self, buf: &[u8], i: usize) -> usize {
         u32::from_le_bytes(buf[i..i + VALUE_WORD].try_into().unwrap()) as usize
     }
 
@@ -115,13 +115,13 @@ impl SSTable {
         let mut hashmap: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
 
         while i < buf.len() {
-            let key_len = self.get_key(&buf, i);
+            let key_len = self.get_key_size(&buf, i);
             i += KEY_WORD;
 
             let key_ = &buf[i..i + key_len];
             i += key_len;
 
-            let value_len = self.get_value(&buf, i);
+            let value_len = self.get_value_size(&buf, i);
             i += VALUE_WORD;
 
             let value_ = &buf[i..i + value_len];

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -78,13 +78,13 @@ impl SSTable {
 
         for (key, value) in sorted_hashmap {
             let key_len = key.len() as u16;
-            let value_len = value.len() as u64;
+            let value_len = value.len() as u32;
             let mut buf = vec![];
             let seek_pos = data_file.stream_position()?;
             index_file.write_u64::<LittleEndian>(seek_pos)?;
             buf.write_u16::<LittleEndian>(key_len)?;
             buf.write_all(key)?;
-            buf.write_u64::<LittleEndian>(value_len)?;
+            buf.write_u32::<LittleEndian>(value_len)?;
             buf.write_all(value)?;
             data_file.write_all(&buf)?;
         }
@@ -97,7 +97,7 @@ impl SSTable {
     }
 
     fn get_value(&self, buf: &[u8], i: usize) -> usize {
-        u64::from_le_bytes(buf[i..i + VALUE_WORD].try_into().unwrap()) as usize
+        u32::from_le_bytes(buf[i..i + VALUE_WORD].try_into().unwrap()) as usize
     }
 
     pub fn as_hashmap(&mut self) -> Result<HashMap<Vec<u8>, Vec<u8>>> {
@@ -149,7 +149,8 @@ impl SSTable {
                     end = index_mid;
                 }
                 Ordering::Equal => {
-                    let value_len = data_file.read_u64::<LittleEndian>()?;
+                    u64::MAX;
+                    let value_len = data_file.read_u32::<LittleEndian>()?;
                     let mut value_buf = vec![0; value_len as usize];
                     data_file.read_exact(value_buf.as_mut_slice())?;
                     let value = value_buf.as_slice();

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -149,7 +149,6 @@ impl SSTable {
                     end = index_mid;
                 }
                 Ordering::Equal => {
-                    u64::MAX;
                     let value_len = data_file.read_u32::<LittleEndian>()?;
                     let mut value_buf = vec![0; value_len as usize];
                     data_file.read_exact(value_buf.as_mut_slice())?;

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -176,9 +176,9 @@ pub fn create_sstable(n_sstables: usize, sstable_dir: &Path) -> SSTable {
 }
 
 pub fn merge(
-    sstable_old: SSTable,
-    sstable_new: SSTable,
-    mut merged_sstable: SSTable,
+    sstable_old: &SSTable,
+    sstable_new: &SSTable,
+    merged_sstable: &mut SSTable,
 ) -> Result<()> {
     let mut map: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
     let (mut i, mut j) = (0, 0);

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -92,11 +92,11 @@ impl SSTable {
         Ok(())
     }
 
-    fn get_key_u64(&self, buf: &[u8], i: usize) -> usize {
-        u64::from_le_bytes(buf[i..i + KEY_WORD].try_into().unwrap()) as usize
+    fn get_key(&self, buf: &[u8], i: usize) -> usize {
+        u16::from_le_bytes(buf[i..i + KEY_WORD].try_into().unwrap()) as usize
     }
 
-    fn get_value_u64(&self, buf: &[u8], i: usize) -> usize {
+    fn get_value(&self, buf: &[u8], i: usize) -> usize {
         u64::from_le_bytes(buf[i..i + VALUE_WORD].try_into().unwrap()) as usize
     }
 
@@ -109,13 +109,13 @@ impl SSTable {
         let mut hashmap: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
 
         while i < buf.len() {
-            let key_len = self.get_key_u64(&buf, i);
+            let key_len = self.get_key(&buf, i);
             i += KEY_WORD;
 
             let key_ = &buf[i..i + key_len];
             i += key_len;
 
-            let value_len = self.get_value_u64(&buf, i);
+            let value_len = self.get_value(&buf, i);
             i += VALUE_WORD;
 
             let value_ = &buf[i..i + value_len];

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -214,5 +214,26 @@ pub fn merge(
             map.clear();
         }
     }
+
+    while i < o_end {
+        let (o_key, o_value) = futil::key_value_at(i, &mut o_index, &mut o_data)?;
+        map.insert(o_key, o_value);
+        i += WORD as u64;
+        if map.len() > 100_000 {
+            merged_sstable.write(&map)?;
+            map.clear();
+        }
+    }
+
+    while j < n_end {
+        let (n_key, n_value) = futil::key_value_at(j, &mut n_index, &mut n_data)?;
+        map.insert(n_key, n_value);
+        j += WORD as u64;
+        if map.len() > 100_000 {
+            merged_sstable.write(&map)?;
+            map.clear();
+        }
+    }
+
     Ok(())
 }

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -93,7 +93,7 @@ impl SSTable {
     }
 
     fn get_key(&self, buf: &[u8], i: usize) -> usize {
-        u16::from_le_bytes(buf[i..i + KEY_WORD].try_into().unwrap()) as usize
+        u64::from_le_bytes(buf[i..i + KEY_WORD].try_into().unwrap()) as usize
     }
 
     fn get_value(&self, buf: &[u8], i: usize) -> usize {

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -1,11 +1,13 @@
-use crate::sstable::constants::{KEY_WORD, TOMBSTONE, VALUE_WORD, WORD};
+use crate::sstable::constants::{KEY_WORD, TOMBSTONE, VALUE_WORD, WORD, RKV};
 use crate::utils::futil;
 use log::error;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::{remove_file, File, OpenOptions};
 use std::io::{Read, Result, Seek, SeekFrom, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+use std::fs::create_dir_all;
 
 #[derive(Clone)]
 pub struct SSTable {

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -77,12 +77,12 @@ impl SSTable {
         });
 
         for (key, value) in sorted_hashmap {
-            let key_len = key.len() as u64;
+            let key_len = key.len() as u16;
             let value_len = value.len() as u64;
             let mut buf = vec![];
             let seek_pos = data_file.stream_position()?;
             index_file.write_u64::<LittleEndian>(seek_pos)?;
-            buf.write_u64::<LittleEndian>(key_len)?;
+            buf.write_u16::<LittleEndian>(key_len)?;
             buf.write_all(key)?;
             buf.write_u64::<LittleEndian>(value_len)?;
             buf.write_all(value)?;
@@ -93,7 +93,7 @@ impl SSTable {
     }
 
     fn get_key(&self, buf: &[u8], i: usize) -> usize {
-        u64::from_le_bytes(buf[i..i + KEY_WORD].try_into().unwrap()) as usize
+        u16::from_le_bytes(buf[i..i + KEY_WORD].try_into().unwrap()) as usize
     }
 
     fn get_value(&self, buf: &[u8], i: usize) -> usize {
@@ -139,7 +139,7 @@ impl SSTable {
             index_file.seek(SeekFrom::Start(index_mid * WORD as u64))?;
             let data_mid = index_file.read_u64::<LittleEndian>()?;
             data_file.seek(SeekFrom::Start(data_mid))?;
-            let key_len = data_file.read_u64::<LittleEndian>()?;
+            let key_len = data_file.read_u16::<LittleEndian>()?;
             let mut key_buf = vec![0; key_len as usize];
             data_file.read_exact(key_buf.as_mut_slice())?;
             let current_key = key_buf.as_slice();

--- a/src/sstable/sst.rs
+++ b/src/sstable/sst.rs
@@ -237,3 +237,12 @@ pub fn merge(
 
     Ok(())
 }
+
+pub fn merge_sstables(sstables: Vec<SSTable>, sstable_dir: &Path) -> Result<SSTable> {
+    let mut merged_sstable = create_sstable(sstables.len(), sstable_dir);
+    for (sstable_old, sstable_new) in sstables.iter().zip(sstables.iter().skip(1)) {
+        merge(sstable_old, sstable_new, &mut merged_sstable)?;
+    }
+
+    Ok(merged_sstable)
+}

--- a/src/sstable/sstable_test.rs
+++ b/src/sstable/sstable_test.rs
@@ -2,7 +2,7 @@
 mod test {
     use crate::sstable::sst::SSTable;
     use std::{
-        collections::HashMap,
+        collections::BTreeMap,
         panic::{self, AssertUnwindSafe},
     };
     use tempfile::TempDir;
@@ -21,7 +21,7 @@ mod test {
             };
             let key = b"test_key";
             let value = b"test_value";
-            let mut store = HashMap::new();
+            let mut store = BTreeMap::new();
             store.insert(key.to_vec(), value.to_vec());
             match sstable.write(&store) {
                 Ok(_) => (),

--- a/src/store/lsm_store.rs
+++ b/src/store/lsm_store.rs
@@ -1,5 +1,4 @@
 use log::{debug, error};
-use std::fs::create_dir_all;
 use std::io::Result;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -7,10 +6,9 @@ use std::thread;
 use std::{collections::HashMap, path::PathBuf};
 
 use glob::glob;
-use uuid::Uuid;
 
 use crate::sstable::constants::{RKV, TOMBSTONE};
-use crate::sstable::sst::SSTable;
+use crate::sstable::sst::{SSTable, create_sstable};
 
 /// A key value store implemented as an LSM Tree.
 ///
@@ -235,16 +233,6 @@ fn parallel_search(sstables: &mut Vec<SSTable>, k: Vec<u8>) -> Option<Vec<u8>> {
 
     let result = result.lock().unwrap();
     result.clone()
-}
-
-fn create_sstable(n_sstables: usize, sstable_dir: &Path) -> SSTable {
-    let uuid = Uuid::new_v4();
-    let idx = n_sstables + 1;
-    let slug = format!("{}-{}.{}", idx, uuid, RKV);
-    let dirname = sstable_dir.join(RKV).join("data");
-    create_dir_all(dirname.clone()).unwrap();
-    let filename = dirname.join(slug);
-    SSTable::new(filename, true, true, true).unwrap()
 }
 
 fn compaction(sstables: &mut Vec<SSTable>, sstable_dir: &Path) -> SSTable {

--- a/src/store/lsm_store.rs
+++ b/src/store/lsm_store.rs
@@ -3,7 +3,7 @@ use std::io::Result;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf};
 
 use glob::glob;
 
@@ -25,7 +25,7 @@ use crate::sstable::sst::{SSTable, create_sstable};
 /// ```
 pub struct KVStore {
     /// memtable is
-    memtable: HashMap<Vec<u8>, Vec<u8>>,
+    memtable: BTreeMap<Vec<u8>, Vec<u8>>,
     mem_size: u64,
     max_bytes: u64,
     sstables: Vec<SSTable>,
@@ -35,7 +35,7 @@ pub struct KVStore {
 impl KVStore {
     pub fn new(size: u64, sstable_dir: PathBuf) -> Self {
         let mut store = KVStore {
-            memtable: HashMap::new(),
+            memtable: BTreeMap::new(),
             mem_size: 0,
             max_bytes: size,
             sstables: vec![],
@@ -115,7 +115,7 @@ impl KVStore {
         if self.sstables.len() > 2 {
             self.compaction();
         }
-        self.memtable = HashMap::new();
+        self.memtable = BTreeMap::new();
         self.mem_size = 0;
         Ok(())
     }
@@ -236,10 +236,10 @@ fn parallel_search(sstables: &mut Vec<SSTable>, k: Vec<u8>) -> Option<Vec<u8>> {
 }
 
 fn compaction(sstables: &mut Vec<SSTable>, sstable_dir: &Path) -> SSTable {
-    let mut store: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
+    let mut store: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
     let n_sstables = sstables.len();
     for sstable in &mut *sstables {
-        if let Ok(hashmap) = sstable.as_hashmap() {
+        if let Ok(hashmap) = sstable.as_map() {
             store.extend(hashmap)
         }
     }

--- a/src/utils/futil.rs
+++ b/src/utils/futil.rs
@@ -1,0 +1,45 @@
+use crate::sstable::constants::{KEY_WORD, VALUE_WORD, WORD};
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use std::fs::File;
+use std::io::{Read, Result, Seek, SeekFrom, Write};
+
+pub fn set_key(buf: &mut Vec<u8>, key_len: usize, key: &[u8]) -> Result<()> {
+    buf.write_u16::<LittleEndian>(key_len as u16)?;
+    buf.write_all(key)
+}
+
+pub fn set_value(buf: &mut Vec<u8>, value_len: usize, value: &[u8]) -> Result<()> {
+    buf.write_u32::<LittleEndian>(value_len as u32)?;
+    buf.write_all(value)
+}
+
+pub fn get_key_size(buf: &[u8], i: usize) -> usize {
+    u16::from_le_bytes(buf[i..i + KEY_WORD].try_into().unwrap()) as usize
+}
+
+pub fn get_value_size(buf: &[u8], i: usize) -> usize {
+    u32::from_le_bytes(buf[i..i + VALUE_WORD].try_into().unwrap()) as usize
+}
+
+pub fn key_at(pos: u64, index: &mut File, data: &mut File) -> Result<Vec<u8>> {
+    index.seek(SeekFrom::Start(pos * WORD as u64))?;
+    let data_mid = index.read_u64::<LittleEndian>()?;
+    data.seek(SeekFrom::Start(data_mid))?;
+
+    let key_len = data.read_u16::<LittleEndian>()?;
+    let mut key_buf = vec![0; key_len as usize];
+
+    data.read_exact(key_buf.as_mut_slice())?;
+    Ok(key_buf)
+}
+
+pub fn get_value(data: &mut File) -> Result<Vec<u8>> {
+    let value_len = data.read_u32::<LittleEndian>()?;
+    let mut value_buf = vec![0; value_len as usize];
+    data.read_exact(value_buf.as_mut_slice())?;
+    Ok(value_buf)
+}
+
+pub fn set_index(index_file: &mut File, index: u64) -> Result<()> {
+    index_file.write_u64::<LittleEndian>(index)
+}

--- a/src/utils/futil.rs
+++ b/src/utils/futil.rs
@@ -21,23 +21,18 @@ pub fn get_value_size(buf: &[u8], i: usize) -> usize {
     u32::from_le_bytes(buf[i..i + VALUE_WORD].try_into().unwrap()) as usize
 }
 
-pub fn key_at(pos: u64, index: &mut File, data: &mut File) -> Result<Vec<u8>> {
+pub fn key_value_at(pos: u64, index: &mut File, data: &mut File) -> Result<(Vec<u8>, Vec<u8>)> {
     index.seek(SeekFrom::Start(pos * WORD as u64))?;
     let data_mid = index.read_u64::<LittleEndian>()?;
     data.seek(SeekFrom::Start(data_mid))?;
-
     let key_len = data.read_u16::<LittleEndian>()?;
     let mut key_buf = vec![0; key_len as usize];
-
     data.read_exact(key_buf.as_mut_slice())?;
-    Ok(key_buf)
-}
 
-pub fn get_value(data: &mut File) -> Result<Vec<u8>> {
     let value_len = data.read_u32::<LittleEndian>()?;
     let mut value_buf = vec![0; value_len as usize];
     data.read_exact(value_buf.as_mut_slice())?;
-    Ok(value_buf)
+    Ok((key_buf, value_buf))
 }
 
 pub fn set_index(index_file: &mut File, index: u64) -> Result<()> {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod futil;


### PR DESCRIPTION
We create a file utility to abstract low level read/write operations.
This reduces errors related to the right byte sizes for keys or values.

There are a few optimizations as well:
- Using `BTreeMap` over `HashMap`. 
- Reducing the size of the keys to `u16` and values to `u32`.